### PR TITLE
fix Py3 compatibility and make Flake8 happier

### DIFF
--- a/ckanext/qa/bin/common.py
+++ b/ckanext/qa/bin/common.py
@@ -1,4 +1,7 @@
+# encoding: utf-8
+
 from ckan.plugins import toolkit
+
 
 def load_config(config_filepath):
     toolkit.load_config(config_filepath)
@@ -48,5 +51,5 @@ def get_resources(state='active', publisher_ref=None, resource_id=None, dataset_
         resources = resources.filter(model.Resource.id == resource_id)
         criteria.append('Resource:%s' % resource_id)
     resources = resources.all()
-    print ('%i resources (%s)' % (len(resources), ' '.join(criteria)))
+    print('%i resources (%s)' % (len(resources), ' '.join(criteria)))
     return resources

--- a/ckanext/qa/bin/migrate_task_status.py
+++ b/ckanext/qa/bin/migrate_task_status.py
@@ -59,7 +59,7 @@ def migrate(options):
         # time, so some timezone nonesense going on. Can't do much.
         archival = Archival.get_for_resource(res.id)
         if not archival:
-            print (add_stat('QA but no Archival data', res, stats))
+            print(add_stat('QA but no Archival data', res, stats))
             continue
         archival_date = archival.updated
         # the state of the resource was as it was archived on the date of
@@ -112,10 +112,10 @@ def migrate(options):
                 model.Session.add(qa)
             add_stat('Added to QA table', res, stats)
 
-    print ('Summary\n', stats.report())
+    print('Summary\n', stats.report())
     if options.write:
         model.repo.commit_and_remove()
-        print ('Written')
+        print('Written')
 
 
 def add_stat(outcome, res, stats, extra_info=None):

--- a/ckanext/qa/bin/running_stats.py
+++ b/ckanext/qa/bin/running_stats.py
@@ -14,7 +14,7 @@ for package in packages:
         package_stats.increment('deleted')
     else:
         package_stats.increment('not deleted')
-print package_stats.report()
+print(package_stats.report())
 > deleted: 30
 > not deleted: 70
 
@@ -26,7 +26,7 @@ for package in packages:
         package_stats.add('deleted', package.name)
     else:
         package_stats.add('not deleted' package.name)
-print package_stats.report()
+print(package_stats.report())
 > deleted: 30 pollution-uk, flood-regions, river-quality, ...
 > not deleted: 70 spending-bristol, ...
 
@@ -34,6 +34,7 @@ print package_stats.report()
 
 import copy
 import datetime
+import six
 
 
 class StatsCount(dict):
@@ -68,9 +69,9 @@ class StatsCount(dict):
             report_dict[category] = self.report_value(category)
 
         if order_by_title:
-            items = sorted(report_dict.items())
+            items = sorted(six.iteritems(report_dict))
         else:
-            items = sorted(report_dict.items(),
+            items = sorted(six.iteritems(report_dict),
                            key=lambda x: -x[1][1])
 
         for category, value_tuple in items:

--- a/ckanext/qa/cli.py
+++ b/ckanext/qa/cli.py
@@ -1,5 +1,8 @@
+# encoding: utf-8
+
 import click
 import ckanext.qa.commands as commands
+
 
 def get_commands():
 

--- a/ckanext/qa/commands.py
+++ b/ckanext/qa/commands.py
@@ -92,50 +92,50 @@ def update(args, queue):
     log.info('Completed queueing')
 
 def view(package_ref=None):
-    
+
     q = model.Session.query(model.TaskStatus).filter_by(task_type='qa')
-    print ('QA records - %i TaskStatus rows' % q.count())
-    print ('      across %i Resources' % q.distinct('entity_id').count())
+    print('QA records - %i TaskStatus rows' % q.count())
+    print('      across %i Resources' % q.distinct('entity_id').count())
 
     if package_ref:
         pkg = model.Package.get(package_ref)
-        print ('Package %s %s' % (pkg.name, pkg.id))
+        print('Package %s %s' % (pkg.name, pkg.id))
         for res in pkg.resources:
-            print ('Resource %s' % res.id)
+            print('Resource %s' % res.id)
             for row in q.filter_by(entity_id=res.id):
-                print ('* %s = %r error=%r' % (row.key, row.value,
+                print('* %s = %r error=%r' % (row.key, row.value,
                                                 row.error))
 
 def migrate():
     q_status = model.Session.query(model.TaskStatus) \
         .filter_by(task_type='qa') \
         .filter_by(key='status')
-    print ('* %s with "status" will be deleted e.g. %s' % (q_status.count(),
+    print('* %s with "status" will be deleted e.g. %s' % (q_status.count(),
                                                             q_status.first()))
     q_failures = model.Session.query(model.TaskStatus) \
         .filter_by(task_type='qa') \
         .filter_by(key='openness_score_failure_count')
-    print ('* %s with openness_score_failure_count to be deleted e.g.\n%s'\
+    print('* %s with openness_score_failure_count to be deleted e.g.\n%s'\
         % (q_failures.count(), q_failures.first()))
     q_score = model.Session.query(model.TaskStatus) \
         .filter_by(task_type='qa') \
         .filter_by(key='openness_score')
-    print ('* %s with openness_score to migrate e.g.\n%s' % \
+    print('* %s with openness_score to migrate e.g.\n%s' % \
         (q_score.count(), q_score.first()))
     q_reason = model.Session.query(model.TaskStatus) \
         .filter_by(task_type='qa') \
         .filter_by(key='openness_score_reason')
-    print ('* %s with openness_score_reason to migrate e.g.\n%s' % \
+    print('* %s with openness_score_reason to migrate e.g.\n%s' % \
         (q_reason.count(), q_reason.first()))
     input('Press Enter to continue')
 
     q_status.delete()
     model.Session.commit()
-    print ('..."status" deleted')
+    print('..."status" deleted')
 
     q_failures.delete()
     model.Session.commit()
-    print ('..."openness_score_failure_count" deleted')
+    print('..."openness_score_failure_count" deleted')
 
     for task_status in q_score:
         reason_task_status = q_reason \
@@ -154,36 +154,36 @@ def migrate():
             'is_broken': None,
             })
         model.Session.commit()
-    print ('..."openness_score" and "openness_score_reason" migrated')
+    print('..."openness_score" and "openness_score_reason" migrated')
     count = q_reason.count()
     q_reason.delete()
     model.Session.commit()
-    print ('... %i remaining "openness_score_reason" deleted' % count)
+    print('... %i remaining "openness_score_reason" deleted' % count)
 
     model.Session.flush()
     model.Session.remove()
-    print ('Migration succeeded')
+    print('Migration succeeded')
 
 def clean():
-    print ('Before:')
+    print('Before:')
     view()
 
     q = model.Session.query(model.TaskStatus).filter_by(task_type='qa')
     q.delete()
     model.Session.commit()
 
-    print ('After:')
+    print('After:')
     view()
 
 def sniff(args):
     from ckanext.qa.sniff_format import sniff_file_format
     if len(args) < 1:
-        print ('Not enough arguments', args)
+        print('Not enough arguments', args)
         sys.exit(1)
     for filepath in args[0:]:
         format_ = sniff_file_format(filepath)
         if format_:
-            print ('Detected as: %s - %s' % (format_['format'],
+            print('Detected as: %s - %s' % (format_['format'],
                                             filepath))
         else:
-            print ('ERROR: Could not recognise format of: %s' % filepath)
+            print('ERROR: Could not recognise format of: %s' % filepath)

--- a/ckanext/qa/controllers.py
+++ b/ckanext/qa/controllers.py
@@ -6,8 +6,13 @@ This controller exposes only one action: check_link
 import json
 import mimetypes
 import posixpath
-import urllib
-import urlparse
+import six
+import six.moves.urllib.parse as urlparse
+# this move isn't covered in the 'six' module
+if six.PY2:
+    from urllib import splittype
+else:
+    from urllib.parse import splittype
 
 from ckan.lib.base import request, BaseController
 from ckan.lib.helpers import parse_rfc_2822_date
@@ -78,7 +83,7 @@ class LinkCheckerController(BaseController):
         """
 
         # If a user enters "www.example.com" then we assume they meant "http://www.example.com"
-        scheme, path = urllib.splittype(url)
+        scheme, path = splittype(url)
         if not scheme:
             url = 'http://' + path
 
@@ -103,7 +108,7 @@ class LinkCheckerController(BaseController):
             result['size'] = headers.get('content-length', '')
             result['last_modified'] = self._parse_and_format_date(headers.get('last-modified', ''))
         except LinkCheckerError as e:
-            result['url_errors'].append(str(e))
+            result['url_errors'].append(six.text_type(e))
         return result
 
     def _extract_file_format(self, url, headers):

--- a/ckanext/qa/lib.py
+++ b/ckanext/qa/lib.py
@@ -1,7 +1,10 @@
-import os
+# encoding: utf-8
+
 import json
-import re
 import logging
+import os
+import re
+import six
 
 from ckan.plugins.toolkit import config
 
@@ -25,7 +28,7 @@ def compat_enqueue(name, fn, queue, args=None):
         # Fallback to Celery
         import uuid
         from ckan.lib.celery_app import celery
-        celery.send_task(name, args=args + [queue], task_id=str(uuid.uuid4()))
+        celery.send_task(name, args=args + [queue], task_id=six.text_type(uuid.uuid4()))
 
 
 def resource_format_scores():
@@ -87,7 +90,7 @@ def munge_format_to_be_canonical(format_name):
 
 def create_qa_update_package_task(package, queue):
     compat_enqueue('qa.update_package', tasks.update_package,
-                   queue,  args=[package.id])
+                   queue, args=[package.id])
     log.debug('QA of package put into queue %s: %s',
               queue, package.name)
 

--- a/ckanext/qa/logic/action.py
+++ b/ckanext/qa/logic/action.py
@@ -30,7 +30,7 @@ def qa_resource_show(context, data_dict):
         'name': pkg.name,
         'title': pkg.title,
         'id': res.id
-        }
+    }
     return_dict['archival'] = archival.as_dict()
     return_dict.update(qa.as_dict())
     return return_dict

--- a/ckanext/qa/model.py
+++ b/ckanext/qa/model.py
@@ -1,5 +1,8 @@
+# encoding: utf-8
+
 import uuid
 import datetime
+import six
 
 from sqlalchemy import Column
 from sqlalchemy import types
@@ -15,7 +18,7 @@ Base = declarative_base()
 
 
 def make_uuid():
-    return str(uuid.uuid4())
+    return six.text_type(uuid.uuid4())
 
 
 class QA(Base):
@@ -40,7 +43,7 @@ class QA(Base):
 
     def __repr__(self):
         summary = 'score=%s format=%s' % (self.openness_score, self.format)
-        details = str(self.openness_score_reason).encode('unicode_escape')
+        details = six.text_type(self.openness_score_reason).encode('unicode_escape')
         package = model.Package.get(self.package_id)
         package_name = package.name if package else '?%s?' % self.package_id
         return '<QA %s /dataset/%s/resource/%s %s>' % \

--- a/ckanext/qa/plugin.py
+++ b/ckanext/qa/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import logging
 
 import ckan.model as model
@@ -6,9 +8,7 @@ import ckan.plugins as p
 from ckanext.archiver.interfaces import IPipe
 from ckanext.qa.logic import action, auth
 from ckanext.qa.model import QA, aggregate_qa_for_a_dataset
-import ckanext.qa.helpers as helpers
-import ckanext.qa.lib as lib
-import ckanext.qa.cli as cli
+from ckanext.qa import cli, helpers, lib
 from ckanext.report.interfaces import IReport
 
 
@@ -69,7 +69,7 @@ class QAPlugin(p.SingletonPlugin, p.toolkit.DefaultDatasetForm):
         return {
             'qa_resource_show': action.qa_resource_show,
             'qa_package_openness_show': action.qa_package_openness_show,
-            }
+        }
 
     # IAuthFunctions
 
@@ -77,7 +77,7 @@ class QAPlugin(p.SingletonPlugin, p.toolkit.DefaultDatasetForm):
         return {
             'qa_resource_show': auth.qa_resource_show,
             'qa_package_openness_show': auth.qa_package_openness_show,
-            }
+        }
 
     # ITemplateHelpers
 
@@ -87,7 +87,7 @@ class QAPlugin(p.SingletonPlugin, p.toolkit.DefaultDatasetForm):
             helpers.qa_openness_stars_resource_html,
             'qa_openness_stars_dataset_html':
             helpers.qa_openness_stars_dataset_html,
-            }
+        }
 
     # IPackageController
 

--- a/ckanext/qa/reports.py
+++ b/ckanext/qa/reports.py
@@ -1,5 +1,10 @@
+# encoding: utf-8
+
 from collections import Counter
 import copy
+import logging
+import six
+
 try:
     from collections import OrderedDict  # from python 2.7
 except ImportError:
@@ -10,7 +15,6 @@ import ckan.model as model
 import ckan.plugins as p
 from ckanext.report import lib
 
-import logging
 
 log = logging.getLogger(__name__)
 
@@ -71,9 +75,9 @@ def openness_index(include_sub_organizations=False):
         results = counts
 
     table = []
-    for org_name, org_counts in results.items():
-        total_stars = sum([k*v for k, v in org_counts['score_counts'].items() if k])
-        num_pkgs_scored = sum([v for k, v in org_counts['score_counts'].items()
+    for org_name, org_counts in six.iteritems(results):
+        total_stars = sum([k * v for k, v in six.iteritems(org_counts['score_counts']) if k])
+        num_pkgs_scored = sum([v for k, v in six.iteritems(org_counts['score_counts'])
                               if k is not None])
         average_stars = round(float(total_stars) / num_pkgs_scored, 1) \
             if num_pkgs_scored else 0.0
@@ -82,7 +86,7 @@ def openness_index(include_sub_organizations=False):
             ('organization_name', org_name),
             ('total_stars', total_stars),
             ('average_stars', average_stars),
-            ))
+        ))
         row.update(jsonify_counter(org_counts['score_counts']))
         table.append(row)
 
@@ -136,11 +140,11 @@ def openness_for_organization(organization=None, include_sub_organizations=False
                 ('organization_title', org.title),
                 ('openness_score', qa['openness_score']),
                 ('openness_score_reason', qa['openness_score_reason']),
-                )))
+            )))
             score_counts[qa['openness_score']] += 1
 
-    total_stars = sum([k*v for k, v in score_counts.items() if k])
-    num_pkgs_with_stars = sum([v for k, v in score_counts.items()
+    total_stars = sum([k * v for k, v in six.iteritems(score_counts) if k])
+    num_pkgs_with_stars = sum([v for k, v in six.iteritems(score_counts)
                                if k is not None])
     average_stars = round(float(total_stars) / num_pkgs_with_stars, 1) \
         if num_pkgs_with_stars else 0.0
@@ -172,14 +176,14 @@ openness_report_info = {
     'option_combinations': openness_report_combinations,
     'generate': openness_report,
     'template': 'report/openness.html',
-    }
+}
 
 
 def jsonify_counter(counter):
     # When counters are stored as JSON, integers become strings. Do the conversion
     # here to ensure that when you run the report the first time, you get the same
     # response as subsequent times that go through the cache/JSON.
-    return dict((str(k) if k is not None else k, v) for k, v in counter.items())
+    return dict((six.text_type(k) if k is not None else k, v) for k, v in six.iteritems(counter))
 
 
 def add_progress_bar(iterable, caption=None):

--- a/ckanext/qa/sniff_format.py
+++ b/ckanext/qa/sniff_format.py
@@ -1,9 +1,12 @@
+# encoding: utf-8
+
 import re
 import zipfile
 import os
 from collections import defaultdict
+import six
 import subprocess
-from io import StringIO, BytesIO
+from six import BytesIO
 
 import xlrd
 import magic
@@ -15,6 +18,7 @@ from ckan.lib import helpers as ckan_helpers
 import logging
 
 log = logging.getLogger(__name__)
+
 
 def sniff_file_format(filepath):
     '''For a given filepath, work out what file format it is.
@@ -33,7 +37,7 @@ def sniff_file_format(filepath):
     '''
     format_ = None
     log.info('Sniffing file format of: %s', filepath)
-    filepath_utf8 = filepath.encode('utf8') if isinstance(filepath, str) \
+    filepath_utf8 = filepath.encode('utf8') if isinstance(filepath, six.string_types) \
         else filepath
     mime_type = magic.from_file(filepath_utf8, mime=True)
     log.info('Magic detects file as: %s', mime_type)
@@ -139,14 +143,14 @@ def is_json(buf):
     JSON format.'''
     string = '"[^"]*"'
     string_re = re.compile(string)
-    number_re = re.compile('-?\d+(\.\d+)?([eE][+-]?\d+)?')
-    extra_values_re = re.compile('true|false|null')
-    object_start_re = re.compile('{%s:\s?' % string)
-    object_middle_re = re.compile('%s:\s?' % string)
-    object_end_re = re.compile('}')
-    comma_re = re.compile(',\s?')
-    array_start_re = re.compile('\[')
-    array_end_re = re.compile('\]')
+    number_re = re.compile(r'-?\d+(\.\d+)?([eE][+-]?\d+)?')
+    extra_values_re = re.compile(r'true|false|null')
+    object_start_re = re.compile(r'{%s:\s?' % string)
+    object_middle_re = re.compile(r'%s:\s?' % string)
+    object_end_re = re.compile(r'}')
+    comma_re = re.compile(r',\s?')
+    array_start_re = re.compile(r'\[')
+    array_end_re = re.compile(r'\]')
     any_value_regexs = [string_re, number_re, object_start_re, array_start_re, extra_values_re]
 
     # simplified state machine - just looks at stack of object/array and
@@ -188,7 +192,7 @@ def is_json(buf):
             log.info('Not JSON - %i matches', number_of_matches)
             return False
         match_length = matcher.match(part_of_buf).end()
-        # print "MATCHED %r %r %s" % (matcher.match(part_of_buf).string[:match_length], matcher.pattern, state_stack)
+        # print("MATCHED %r %r %s" % (matcher.match(part_of_buf).string[:match_length], matcher.pattern, state_stack))
         pos += match_length
         number_of_matches += 1
         if number_of_matches > 5:
@@ -258,7 +262,7 @@ def _is_spreadsheet(table_set, format):
 
 def is_html(buf):
     '''If this buffer is HTML, return that format type, else None.'''
-    xml_re = '.{0,3}\s*(<\?xml[^>]*>\s*)?(<!doctype[^>]*>\s*)?<html[^>]*>'
+    xml_re = r'.{0,3}\s*(<\?xml[^>]*>\s*)?(<!doctype[^>]*>\s*)?<html[^>]*>'
     match = re.match(xml_re, buf, re.IGNORECASE)
     if match:
         log.info('HTML tag detected')
@@ -268,7 +272,7 @@ def is_html(buf):
 
 def is_iati(buf):
     '''If this buffer is IATI format, return that format type, else None.'''
-    xml_re = '.{0,3}\s*(<\?xml[^>]*>\s*)?(<!doctype[^>]*>\s*)?<iati-(activities|organisations)[^>]*>'
+    xml_re = r'.{0,3}\s*(<\?xml[^>]*>\s*)?(<!doctype[^>]*>\s*)?<iati-(activities|organisations)[^>]*>'
     match = re.match(xml_re, buf, re.IGNORECASE)
     if match:
         log.info('IATI tag detected')
@@ -279,13 +283,13 @@ def is_iati(buf):
 def is_xml_but_without_declaration(buf):
     '''Decides if this is a buffer of XML, but missing the usual <?xml ...?>
     tag.'''
-    xml_re = '.{0,3}\s*(<\?xml[^>]*>\s*)?(<!doctype[^>]*>\s*)?<([^>\s]*)([^>]*)>'
+    xml_re = r'.{0,3}\s*(<\?xml[^>]*>\s*)?(<!doctype[^>]*>\s*)?<([^>\s]*)([^>]*)>'
     match = re.match(xml_re, buf, re.IGNORECASE)
     if match:
         top_level_tag_name, top_level_tag_attributes = match.groups()[-2:]
         if 'xmlns:' not in top_level_tag_attributes and \
-            (len(top_level_tag_name) > 20 or
-             len(top_level_tag_attributes) > 200):
+            (len(top_level_tag_name) > 20
+             or len(top_level_tag_attributes) > 200):
             log.debug('Not XML (without declaration) - unlikely length first tag: <%s %s>',
                       top_level_tag_name, top_level_tag_attributes)
             return False
@@ -321,7 +325,7 @@ def get_xml_variant_without_xml_declaration(buf):
     try:
         p.Parse(buf)
     except GotFirstTag as e:
-        top_level_tag_name = str(e).lower()
+        top_level_tag_name = six.text_type(e).lower()
     except xml.sax.SAXException as e:
         log.info('Sax parse error: %s %s', e, buf)
         return {'format': 'XML'}
@@ -356,8 +360,8 @@ def has_rdfa(buf):
         return False
 
     # more rigorous check for them as tag attributes
-    about_re = '<[^>]+\sabout="[^"]+"[^>]*>'
-    property_re = '<[^>]+\sproperty="[^"]+"[^>]*>'
+    about_re = r'<[^>]+\sabout="[^"]+"[^>]*>'
+    property_re = r'<[^>]+\sproperty="[^"]+"[^>]*>'
     # remove CR to catch tags spanning more than one line
     # buf = re.sub('\r\n', ' ', buf)
     if not re.search(about_re, buf):
@@ -536,12 +540,12 @@ def turtle_regex():
     '''
     global turtle_regex_
     if not turtle_regex_:
-        rdf_term = '(<[^ >]+>|_:\S+|".+?"(@\w+)?(\^\^\S+)?|\'.+?\'(@\w+)?(\^\^\S+)?|""".+?"""(@\w+)' \
-                   '?(\^\^\S+)?|\'\'\'.+?\'\'\'(@\w+)?(\^\^\S+)?|[+-]?([0-9]+|[0-9]*\.[0-9]+)(E[+-]?[0-9]+)?|false|true)'
+        rdf_term = r'(<[^ >]+>|_:\S+|".+?"(@\w+)?(\^\^\S+)?|\'.+?\'(@\w+)?(\^\^\S+)?|""".+?"""(@\w+)' \
+                   r'?(\^\^\S+)?|\'\'\'.+?\'\'\'(@\w+)?(\^\^\S+)?|[+-]?([0-9]+|[0-9]*\.[0-9]+)(E[+-]?[0-9]+)?|false|true)'
 
-        # simple case is: triple_re = '^T T T \.$'.replace('T', rdf_term)
+        # simple case is: triple_re = r'^T T T \.$'.replace('T', rdf_term)
         # but extend to deal with multiple predicate-objects:
-        # triple = '^T T T\s*(;\s*T T\s*)*\.\s*$'.replace('T', rdf_term).replace(' ', '\s+')
-        triple = '(^T|;)\s*T T\s*(;|\.\s*$)'.replace('T', rdf_term).replace(' ', '\s+')
+        # triple = r'^T T T\s*(;\s*T T\s*)*\.\s*$'.replace('T', rdf_term).replace(' ', r'\s+')
+        triple = r'(^T|;)\s*T T\s*(;|\.\s*$)'.replace('T', rdf_term).replace(' ', r'\s+')
         turtle_regex_ = re.compile(triple, re.MULTILINE)
     return turtle_regex_

--- a/ckanext/qa/tasks.py
+++ b/ckanext/qa/tasks.py
@@ -6,8 +6,7 @@ import datetime
 import json
 import os
 import traceback
-from urllib.parse import urlparse
-import routes
+import six
 
 from ckan.common import _
 
@@ -73,7 +72,7 @@ def load_translations(lang):
     registry.prepare()
 
     class FakePylons:
-            translator = None
+        translator = None
     fakepylons = FakePylons()
 
     class FakeRequest:
@@ -100,7 +99,7 @@ def update_package(package_id):
         update_package_(package_id)
     except Exception as e:
         log.error('Exception occurred during QA update_package: %s: %s',
-                  e.__class__.__name__,  str(e))
+                  e.__class__.__name__, e)
         raise
 
 
@@ -138,7 +137,7 @@ def update(ckan_ini_filepath=None, resource_id=None):
         update_resource_(resource_id)
     except Exception as e:
         log.error('Exception occurred during QA update_resource: %s: %s',
-                  e.__class__.__name__,  str(e))
+                  e.__class__.__name__, e)
         raise
 
 
@@ -206,8 +205,6 @@ def resource_score(resource):
     score_reason = ''
     format_ = None
 
-    #register_translator()
-
     try:
         score_reasons = []  # a list of strings detailing how we scored it
         archival = Archival.get_for_resource(resource_id=resource.id)
@@ -237,8 +234,8 @@ def resource_score(resource):
         format_ = format_ or None
     except Exception as e:
         log.error('Unexpected error while calculating openness score %s: %s\nException: %s',
-                  e.__class__.__name__,  str(e), traceback.format_exc())
-        score_reason = _("Unknown error: %s") % str(e)
+                  e.__class__.__name__, e, traceback.format_exc())
+        score_reason = _("Unknown error: %s") % e
         raise
 
     # Even if we can get the link, we should still treat the resource
@@ -278,7 +275,7 @@ def broken_link_error_message(archival):
         else:
             return ''
     messages = [_('File could not be downloaded.'),
-                _('Reason') + ':', str(archival.status) + '.',
+                _('Reason') + ':', six.text_type(archival.status) + '.',
                 _('Error details: %s.') % archival.reason,
                 _('Attempted on %s.') % format_date(archival.updated)]
     last_success = format_date(archival.last_success)

--- a/ckanext/qa/tests/fake_ckan.py
+++ b/ckanext/qa/tests/fake_ckan.py
@@ -10,12 +10,12 @@ TASK_STATUS_ARCHIVER_OK = json.dumps(
                     'last_success': '2008-10-01',
                     'first_failure': '',
                     'failure_count': 0,
-                    }),
+                }),
                 'stack': '',
                 'last_updated': '2008-10-10T19:30:37.536836',
                 }
      }
-    )
+)
 
 request_store = []
 task_status = {'archiver': TASK_STATUS_ARCHIVER_OK,

--- a/ckanext/qa/tests/mock_remote_server.py
+++ b/ckanext/qa/tests/mock_remote_server.py
@@ -7,6 +7,7 @@ from threading import Thread
 from time import sleep
 from wsgiref.simple_server import make_server
 import urllib2
+import six
 import socket
 
 
@@ -37,7 +38,7 @@ class MockHTTPServer(object):
         This uses context manager to make sure the server is stopped::
 
             >>> with MockTestServer().serve() as addr:
-            ...     print urllib2.urlopen('%s/?content=hello+world').read()
+            ...     print(urllib2.urlopen('%s/?content=hello+world').read())
             ...
             'hello world'
         """
@@ -80,8 +81,8 @@ class MockHTTPServer(object):
         called and its return value used.
         """
         modpath, var = varspec.split(':')
-        mod = reduce(getattr, modpath.split('.')[1:], __import__(modpath))
-        var = reduce(getattr, var.split('.'), mod)
+        mod = six.moves.reduce(getattr, modpath.split('.')[1:], __import__(modpath))
+        var = six.moves.reduce(getattr, var.split('.'), mod)
         try:
             return var()
         except TypeError:
@@ -96,7 +97,8 @@ class MockEchoTestServer(MockHTTPServer):
         a 500 error response: 'http://localhost/?status=500'
 
         a 200 OK response, returning the function's docstring:
-         'http://localhost/?status=200;content-type=text/plain;content_var=ckan.tests.lib.test_package_search:test_wsgi_app.__doc__'
+        'http://localhost/?status=200;content-type=text/plain;content_var
+        =ckan.tests.lib.test_package_search:test_wsgi_app.__doc__'
 
     To specify content, use:
 
@@ -116,7 +118,7 @@ class MockEchoTestServer(MockHTTPServer):
         else:
             content = request.str_params.get('content', '')
 
-        if isinstance(content, str):
+        if isinstance(content, six.text_type):
             raise TypeError("Expected raw byte string for content")
 
         headers = [
@@ -125,7 +127,7 @@ class MockEchoTestServer(MockHTTPServer):
             if item[0] not in ('content', 'status')
         ]
         if content:
-            headers += [('Content-Length', str(len(content)))]
+            headers += [('Content-Length', six.binary_type(len(content)))]
         start_response(
             '%d %s' % (status, responses[status]),
             headers

--- a/ckanext/qa/tests/test_link_checker.py
+++ b/ckanext/qa/tests/test_link_checker.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import logging
 from functools import wraps
 import json
@@ -121,12 +123,12 @@ class TestLinkChecker(ControllerTestCase):
         # accept, because browsers accept this
         # see discussion: http://trac.ckan.org/ticket/318
         result = self.check_link(url)
-        print (result)
+        print(result)
         assert_equal(result['url_errors'], [])
 
     @with_mock_url('?status=200 ')
     def test_trailing_whitespace(self, url):
         # accept, because browsers accept this
         result = self.check_link(url)
-        print (result)
+        print(result)
         assert_equal(result['url_errors'], [])

--- a/ckanext/qa/tests/test_sniff_format.py
+++ b/ckanext/qa/tests/test_sniff_format.py
@@ -292,5 +292,5 @@ def test_turtle_regex():
 
 def test_is_ttl__num_triples():
     triple = '<subject> <predicate> <object>; <predicate> <object>.'
-    assert not is_ttl('\n'.join([triple]*2))
-    assert is_ttl('\n'.join([triple]*5))
+    assert not is_ttl('\n'.join([triple] * 2))
+    assert is_ttl('\n'.join([triple] * 5))

--- a/ckanext/qa/tests/test_tasks.py
+++ b/ckanext/qa/tests/test_tasks.py
@@ -78,7 +78,7 @@ class TestTask(BaseCase):
         context = {'model': model, 'ignore_auth': True, 'session': model.Session, 'user': 'test'}
         pkg = {'name': 'testpkg', 'license_id': 'uk-ogl', 'resources': [
             {'url': 'http://test.com/', 'format': 'CSV', 'description': 'Test'}
-            ]}
+        ]}
         pkg = get_action('package_create')(context, pkg)
         resource_dict = pkg['resources'][0]
         res_id = resource_dict['id']
@@ -304,7 +304,7 @@ class TestSaveQaResult(object):
             'openness_score_reason': 'Detected as CSV which scores 3',
             'format': 'CSV',
             'archival_timestamp': datetime.datetime(2015, 12, 16),
-            }
+        }
         qa_result.update(kwargs)
         return qa_result
 
@@ -335,7 +335,7 @@ class TestUpdatePackage(object):
             'url': 'http://example.com/file.csv',
             'title': 'Some data',
             'format': '',
-            }
+        }
         dataset = ckan_factories.Dataset(resources=[resource])
         resource = model.Resource.get(dataset['resources'][0]['id'])
 
@@ -359,7 +359,7 @@ class TestUpdateResource(object):
             'url': 'http://example.com/file.csv',
             'title': 'Some data',
             'format': '',
-            }
+        }
         dataset = ckan_factories.Dataset(resources=[resource])
         resource = model.Resource.get(dataset['resources'][0]['id'])
 


### PR DESCRIPTION
#1 
- Use brackets with 'print' and don't insert a space
- Use 'six' for Py2/Py3 compatible functions
- Mark regex strings with 'r' so we can use any escape sequence
- Fix whitespace and indentation